### PR TITLE
Feature 174670147 use ip proxy

### DIFF
--- a/lib/cors-anywhere.js
+++ b/lib/cors-anywhere.js
@@ -4,6 +4,11 @@
 'use strict';
 
 var httpProxy = require('http-proxy');
+var HttpProxyAgent = require('https-proxy-agent');
+var proxyServer = 'http://185.200.33.128:65432'; // Hard-coded for now. TODO:
+                                                 // randomly choose from the
+                                                 // pool of IPs from oxylabs.
+var agent = new HttpProxyAgent(proxyServer);
 var net = require('net');
 var url = require('url');
 var regexp_tld = require('./regexp-top-level-domain');
@@ -403,6 +408,9 @@ exports.createServer = function createServer(options) {
   var httpProxyOptions = {
     xfwd: true,            // Append X-Forwarded-* headers
   };
+  if (process.env.NODE_ENV !== 'test') {
+    httpProxyOptions.agent = agent;
+  }
   // Allow user to override defaults and add own options
   if (options.httpProxyOptions) {
     Object.keys(options.httpProxyOptions).forEach(function(option) {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   ],
   "dependencies": {
     "http-proxy": "1.11.1",
+    "https-proxy-agent": "5.0.0",
     "proxy-from-env": "0.0.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   },
   "scripts": {
     "lint": "eslint .",
-    "test": "mocha ./test/test*.js --reporter spec",
+    "test": "NODE_ENV=test mocha ./test/test*.js --reporter spec",
     "test-coverage": "istanbul cover ./node_modules/.bin/_mocha -- test/test.js test/test-ratelimit.js --reporter spec",
     "start": "node server.js",
     "deploy:staging": "ecs-deploy -c sd-staging-fargate -n staging-sd-cors-anywhere -i 986110171865.dkr.ecr.us-east-1.amazonaws.com/sd-cors-anywhere:$TRAVIS_BUILD_NUMBER-$(git log --format=%h -1) -r us-east-1 -t 180"

--- a/yarn.lock
+++ b/yarn.lock
@@ -29,6 +29,13 @@ acorn@^5.5.0:
   resolved "https://registry.npmjs.org/acorn/-/acorn-5.7.4.tgz#3e8d8a9947d0599a1796d10225d7432f4a4acf5e"
   integrity sha512-1D++VG7BhrtvQpNbBzovKNc1FLGGEE/oGe7b9xJm/RFHMBeUaUGpluV9RLjZa47YFdPcDAenEYuq9pQPcMdLJg==
 
+agent-base@6:
+  version "6.0.1"
+  resolved "https://registry.npmjs.org/agent-base/-/agent-base-6.0.1.tgz#808007e4e5867decb0ab6ab2f928fbdb5a596db4"
+  integrity sha512-01q25QQDwLSsyfhrKbn8yuur+JNw0H+0Y4JiGIKd3z9aYk/w/2kxD/Upc+t2ZBBSUNff50VjPsSW2YxM8QYKVg==
+  dependencies:
+    debug "4"
+
 ajv-keywords@^1.0.0:
   version "1.5.1"
   resolved "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-1.5.1.tgz#314dd0a4b3368fad3dfcdc54ede6171b886daf3c"
@@ -305,6 +312,13 @@ debug@2.6.8:
   integrity sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=
   dependencies:
     ms "2.0.0"
+
+debug@4:
+  version "4.2.0"
+  resolved "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz#7f150f93920e94c58f5574c2fd01a3110effe7f1"
+  integrity sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==
+  dependencies:
+    ms "2.1.2"
 
 debug@^2.1.1, debug@^2.2.0:
   version "2.6.9"
@@ -842,6 +856,14 @@ http-signature@~1.1.0:
     jsprim "^1.2.2"
     sshpk "^1.7.0"
 
+https-proxy-agent@5.0.0:
+  version "5.0.0"
+  resolved "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz#e2a90542abb68a762e0a0850f6c9edadfd8506b2"
+  integrity sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==
+  dependencies:
+    agent-base "6"
+    debug "4"
+
 ignore@^3.1.2:
   version "3.3.10"
   resolved "https://registry.npmjs.org/ignore/-/ignore-3.3.10.tgz#0a97fb876986e8081c631160f8f9f389157f0043"
@@ -1223,6 +1245,11 @@ ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
   integrity sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=
+
+ms@2.1.2:
+  version "2.1.2"
+  resolved "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
+  integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
 
 mute-stream@0.0.5:
   version "0.0.5"


### PR DESCRIPTION
@vincecampanale 
- https://www.pivotaltracker.com/story/show/175352582
- These are the changes needed to get this proxy to send its request through another proxy.

### How to test
- you are already able to import from quizlet from your home, so this won't demonstrate that the proxy fixes anything for you if you're there, but you can ensure it doesn't break anything. If you're at the office, it should go from not working to working.
- run cors-anywhere locally on this branch with `node server.js`
- for neodarwin, switch to https://github.com/spanishdict/neodarwin/pull/9095 and then change [this line](https://github.com/spanishdict/neodarwin/blob/feature-175352582-prep-for-proxy-proxy/src/components/vocab-import/quizlet/snoop.js#L16) to `const proxy = 'http://localhost:8080';`. 
- You should still be able to import from quizlet

/cc @spanishdict/engineering-sd-engage 